### PR TITLE
fix: remove polyfill.io (comprometido - supply chain attack)

### DIFF
--- a/exercicios/capitulo-ii-produto-interno-no-r2/1-produto-escalar-de-dois-vetores.html
+++ b/exercicios/capitulo-ii-produto-interno-no-r2/1-produto-escalar-de-dois-vetores.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <!-- Include MathJax -->
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
 <script async="" id="MathJax-script" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 <script>
     MathJax = {

--- a/exercicios/capitulo-ii-produto-interno-no-r2/2-modulo-de-um-vetor.html
+++ b/exercicios/capitulo-ii-produto-interno-no-r2/2-modulo-de-um-vetor.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <!-- Include MathJax -->
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
 <script async="" id="MathJax-script" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 <script>
     MathJax = {

--- a/exercicios/capitulo-ii-produto-interno-no-r2/3-distancia-entre-dois-pontos.html
+++ b/exercicios/capitulo-ii-produto-interno-no-r2/3-distancia-entre-dois-pontos.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <!-- Include MathJax -->
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
 <script async="" id="MathJax-script" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 <script>
     MathJax = {

--- a/exercicios/capitulo-ii-produto-interno-no-r2/4-projecao-vetorial.html
+++ b/exercicios/capitulo-ii-produto-interno-no-r2/4-projecao-vetorial.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <!-- Include MathJax -->
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
 <script async="" id="MathJax-script" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 <script>
     MathJax = {

--- a/exercicios/capitulo-ii-produto-interno-no-r2/5-paralelismo-e-ortogonalidade.html
+++ b/exercicios/capitulo-ii-produto-interno-no-r2/5-paralelismo-e-ortogonalidade.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <!-- Include MathJax -->
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
 <script async="" id="MathJax-script" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 <script>
     MathJax = {

--- a/exercicios/capitulo-ii-produto-interno-no-r2/6-angulo-de-dois-vetores.html
+++ b/exercicios/capitulo-ii-produto-interno-no-r2/6-angulo-de-dois-vetores.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <!-- Include MathJax -->
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
 <script async="" id="MathJax-script" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 <script>
     MathJax = {

--- a/exercicios/capitulo-ii-produto-interno-no-r2/7-area-de-triangulo-e-alinhamento-de-tres-pontos.html
+++ b/exercicios/capitulo-ii-produto-interno-no-r2/7-area-de-triangulo-e-alinhamento-de-tres-pontos.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <!-- Include MathJax -->
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
 <script async="" id="MathJax-script" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 <script>
     MathJax = {

--- a/exercicios/capitulo-iii-estudo-da-reta-no-r2/1-equacao-da-reta.html
+++ b/exercicios/capitulo-iii-estudo-da-reta-no-r2/1-equacao-da-reta.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <!-- Include MathJax -->
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
 <script async="" id="MathJax-script" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 <script>
     MathJax = {

--- a/exercicios/capitulo-iii-estudo-da-reta-no-r2/2-posicoes-relativas-e-intersecoes-de-retas.html
+++ b/exercicios/capitulo-iii-estudo-da-reta-no-r2/2-posicoes-relativas-e-intersecoes-de-retas.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <!-- Include MathJax -->
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
 <script async="" id="MathJax-script" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 <script>
     MathJax = {

--- a/exercicios/capitulo-iii-estudo-da-reta-no-r2/3-paralelismo-e-perpendicularidade.html
+++ b/exercicios/capitulo-iii-estudo-da-reta-no-r2/3-paralelismo-e-perpendicularidade.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <!-- Include MathJax -->
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
 <script async="" id="MathJax-script" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 <script>
     MathJax = {

--- a/exercicios/capitulo-iii-estudo-da-reta-no-r2/4-ponto-e-reta-distancia-e-inequacoes.html
+++ b/exercicios/capitulo-iii-estudo-da-reta-no-r2/4-ponto-e-reta-distancia-e-inequacoes.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <!-- Include MathJax -->
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
 <script async="" id="MathJax-script" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 <script>
     MathJax = {

--- a/exercicios/capitulo-iii-estudo-da-reta-no-r2/5-equacao-reduzida-e-inclinacao.html
+++ b/exercicios/capitulo-iii-estudo-da-reta-no-r2/5-equacao-reduzida-e-inclinacao.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <!-- Include MathJax -->
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
 <script async="" id="MathJax-script" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 <script>
     MathJax = {

--- a/exercicios/capitulo-iv-a-circunferencia-no-r2/1-equacao-da-circunferencia.html
+++ b/exercicios/capitulo-iv-a-circunferencia-no-r2/1-equacao-da-circunferencia.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <!-- Include MathJax -->
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
 <script async="" id="MathJax-script" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 <script>
     MathJax = {

--- a/exercicios/capitulo-iv-a-circunferencia-no-r2/2-circunferencia-definida-por-tres-pontos.html
+++ b/exercicios/capitulo-iv-a-circunferencia-no-r2/2-circunferencia-definida-por-tres-pontos.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <!-- Include MathJax -->
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
 <script async="" id="MathJax-script" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 <script>
     MathJax = {

--- a/exercicios/capitulo-iv-a-circunferencia-no-r2/3-posicoes-relativas-e-intersecoes.html
+++ b/exercicios/capitulo-iv-a-circunferencia-no-r2/3-posicoes-relativas-e-intersecoes.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <!-- Include MathJax -->
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
 <script async="" id="MathJax-script" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 <script>
     MathJax = {

--- a/exercicios/capitulo-iv-a-circunferencia-no-r2/4-posicoes-de-um-ponto-em-relacao-a-circunferencia.html
+++ b/exercicios/capitulo-iv-a-circunferencia-no-r2/4-posicoes-de-um-ponto-em-relacao-a-circunferencia.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <!-- Include MathJax -->
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
 <script async="" id="MathJax-script" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 <script>
     MathJax = {

--- a/exercicios/capitulo-iv-a-circunferencia-no-r2/5-coordenadas-polares-e-equacoes-parametricas.html
+++ b/exercicios/capitulo-iv-a-circunferencia-no-r2/5-coordenadas-polares-e-equacoes-parametricas.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <!-- Include MathJax -->
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
 <script async="" id="MathJax-script" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 <script>
     MathJax = {

--- a/exercicios/capitulo-v-lugares-geometricos-as-conicas/1-lugares-geometricos.html
+++ b/exercicios/capitulo-v-lugares-geometricos-as-conicas/1-lugares-geometricos.html
@@ -3,7 +3,6 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
     <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     <script>
     MathJax = {

--- a/exercicios/capitulo-v-lugares-geometricos-as-conicas/2-parabola.html
+++ b/exercicios/capitulo-v-lugares-geometricos-as-conicas/2-parabola.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <!-- Include MathJax -->
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
 <script async="" id="MathJax-script" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 <script>
     MathJax = {

--- a/exercicios/capitulo-v-lugares-geometricos-as-conicas/3-elipse.html
+++ b/exercicios/capitulo-v-lugares-geometricos-as-conicas/3-elipse.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <!-- Include MathJax -->
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
 <script async="" id="MathJax-script" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 <script>
     MathJax = {

--- a/exercicios/capitulo-v-lugares-geometricos-as-conicas/4-hiperbole.html
+++ b/exercicios/capitulo-v-lugares-geometricos-as-conicas/4-hiperbole.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <!-- Include MathJax -->
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
 <script async="" id="MathJax-script" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 <script>
     MathJax = {

--- a/exercicios/capitulo-vi-o-r3-e-a-geometria-analitica-no-espaco/1-espaco-vetorial-r3.html
+++ b/exercicios/capitulo-vi-o-r3-e-a-geometria-analitica-no-espaco/1-espaco-vetorial-r3.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <!-- Include MathJax -->
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
 <script async="" id="MathJax-script" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 <script>
     MathJax = {

--- a/exercicios/capitulo-vi-o-r3-e-a-geometria-analitica-no-espaco/2-produto-interno-no-r3.html
+++ b/exercicios/capitulo-vi-o-r3-e-a-geometria-analitica-no-espaco/2-produto-interno-no-r3.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <!-- Include MathJax -->
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
 <script async="" id="MathJax-script" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 <script>
     MathJax = {

--- a/exercicios/capitulo-vi-o-r3-e-a-geometria-analitica-no-espaco/3-produto-vetorial-e-produto-misto.html
+++ b/exercicios/capitulo-vi-o-r3-e-a-geometria-analitica-no-espaco/3-produto-vetorial-e-produto-misto.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <!-- Include MathJax -->
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
 <script async="" id="MathJax-script" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 <script>
     MathJax = {

--- a/exercicios/capitulo-vi-o-r3-e-a-geometria-analitica-no-espaco/4-areas-e-volumes.html
+++ b/exercicios/capitulo-vi-o-r3-e-a-geometria-analitica-no-espaco/4-areas-e-volumes.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <!-- Include MathJax -->
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
 <script async="" id="MathJax-script" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 <script>
     MathJax = {

--- a/exercicios/capitulo-vi-o-r3-e-a-geometria-analitica-no-espaco/5-equacao-do-plano.html
+++ b/exercicios/capitulo-vi-o-r3-e-a-geometria-analitica-no-espaco/5-equacao-do-plano.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <!-- Include MathJax -->
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
 <script async="" id="MathJax-script" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 <script>
     MathJax = {

--- a/exercicios/capitulo-vi-o-r3-e-a-geometria-analitica-no-espaco/6-equacoes-da-reta.html
+++ b/exercicios/capitulo-vi-o-r3-e-a-geometria-analitica-no-espaco/6-equacoes-da-reta.html
@@ -4,7 +4,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Include MathJax -->
-    <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
     <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     <script>
     MathJax = {

--- a/exercicios/capitulo-vi-o-r3-e-a-geometria-analitica-no-espaco/7-sistemas-de-equacoes-lineares-a-tres-incognitas.html
+++ b/exercicios/capitulo-vi-o-r3-e-a-geometria-analitica-no-espaco/7-sistemas-de-equacoes-lineares-a-tres-incognitas.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <!-- Include MathJax -->
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
 <script async="" id="MathJax-script" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 <script>
     MathJax = {

--- a/exercicios/capitulo-vi-o-r3-e-a-geometria-analitica-no-espaco/8-equacao-da-superficie-esferica.html
+++ b/exercicios/capitulo-vi-o-r3-e-a-geometria-analitica-no-espaco/8-equacao-da-superficie-esferica.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <!-- Include MathJax -->
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
 <script async="" id="MathJax-script" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 <script>
     MathJax = {

--- a/exercicios/template.html
+++ b/exercicios/template.html
@@ -4,7 +4,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Include MathJax -->
-    <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
     <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     <script>
     MathJax = {


### PR DESCRIPTION
O domínio polyfill.io foi comprado por uma empresa chinesa (Funnull) em fevereiro de 2024 e desde junho de 2024 está injetando malware em dispositivos móveis. Este é um ataque de cadeia de suprimentos.

Navegadores modernos já suportam ES6 nativamente, então o polyfill não é mais necessário. O autor original do polyfill recomenda remover completamente qualquer referência ao polyfill.io.

Refs: https://sansec.io/research/polyfill-supply-chain-attack